### PR TITLE
Add a more effiecient way to retrieve the user group membership

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/UserApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/UserApi.java
@@ -10,6 +10,6 @@ public interface UserApi {
     String USER_SELF_ID = "/self";
 
     User getUserForAccessKey(Secret secret);
-    ImmutableList<UserGroup> getUserMembershipName(AccessToken accessToken);
+    @Deprecated ImmutableList<UserGroup> getUserMembershipName(AccessToken accessToken);
     ImmutableList<UserGroup> getUserMembership(AccessToken accessToken);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/UserApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/UserApi.java
@@ -11,4 +11,5 @@ public interface UserApi {
 
     User getUserForAccessKey(Secret secret);
     ImmutableList<UserGroup> getUserMembershipName(AccessToken accessToken);
+    ImmutableList<UserGroup> getUserMembership(AccessToken accessToken);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -147,6 +147,7 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
     public ImmutableList<UserGroup> getUserMembership(AccessToken accessToken) {
         HttpUrl urlUserMembership = Objects.requireNonNull(HttpUrl.parse(this.tuleapConfiguration.getApiBaseUrl() + this.USER_API + this.USER_SELF_ID + this.USER_MEMBERSHIP))
             .newBuilder()

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -102,9 +102,15 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
         }
     }
 
+    /**
+     * @deprecated Use getUserMembership() instead. If you still use this method you should update your Tuleap and use the getUserMembership() which is more efficent.
+     */
+    @Deprecated
     @Override
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
     public ImmutableList<UserGroup> getUserMembershipName(AccessToken accessToken) {
+        LOGGER.info("You are using a deprecated method. Please upgrade your Tuleap and use getUserMembership() instead. ");
+
         HttpUrl urlUserMembership = Objects.requireNonNull(HttpUrl.parse(this.tuleapConfiguration.getApiBaseUrl() + this.USER_API + this.USER_SELF_ID + this.USER_MEMBERSHIP))
             .newBuilder()
             .addEncodedQueryParameter("scope", "project")
@@ -138,6 +144,41 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
         });
 
         return ImmutableList.copyOf(memberships);
+    }
+
+    @Override
+    public ImmutableList<UserGroup> getUserMembership(AccessToken accessToken) {
+        HttpUrl urlUserMembership = Objects.requireNonNull(HttpUrl.parse(this.tuleapConfiguration.getApiBaseUrl() + this.USER_API + this.USER_SELF_ID + this.USER_MEMBERSHIP))
+            .newBuilder()
+            .addEncodedQueryParameter("scope", "project")
+            .addEncodedQueryParameter("format", "full")
+            .build();
+
+        Request req = new Request.Builder()
+            .url(urlUserMembership)
+            .addHeader("Authorization", "Bearer " + accessToken.getAccessToken())
+            .get()
+            .build();
+
+        try (Response response = this.client.newCall(req).execute()) {
+
+            if (response.code() == 400) {
+                return this.getUserMembershipName(accessToken);
+            }
+
+            if (!response.isSuccessful()) {
+                throw new InvalidTuleapResponseException(response);
+            }
+
+            return ImmutableList.copyOf(
+                this.objectMapper.readValue(
+                    Objects.requireNonNull(response.body()).string(),
+                    new TypeReference<ImmutableList<UserGroupEntity>>() {
+                    }
+                ));
+        } catch (IOException | InvalidTuleapResponseException e) {
+            throw new RuntimeException("Error while contacting Tuleap server", e);
+        }
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -182,6 +182,81 @@ public class TuleapApiClientTest {
         assertEquals(resultList.get(2).getProjectName(), expectedList.get(2).getProjectName());
     }
 
+    @Test
+    public void itShouldCallGetUserMembershipNameIfTheServerReturns400() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(400);
+        when(response.isSuccessful()).thenReturn(true);
+
+        String jsonUserMembershipPayload = IOUtils.toString(TuleapApiClientTest.class.getResourceAsStream("user_membership_payload.json"), UTF_8.name());
+        String jsonUserGroupsPayload1 = IOUtils.toString(TuleapApiClientTest.class.getResourceAsStream("user_groups_payload1.json"), UTF_8.name());
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.string())
+            .thenReturn(jsonUserMembershipPayload)
+            .thenReturn(jsonUserGroupsPayload1);
+
+        UserGroup userGroup1 = new UserGroupEntity("project_members", new ProjectEntity("coincoin", 22));
+        List<UserGroup> expectedList = ImmutableList.of(userGroup1);
+
+        List<UserGroup> resultList = this.tuleapApiClient.getUserMembership(this.accessToken);
+
+        assertEquals(expectedList.get(0).getGroupName(), resultList.get(0).getGroupName());
+        assertEquals(expectedList.get(0).getProjectName(), resultList.get(0).getProjectName());
+    }
+
+    @Test
+    public void itShouldReturnUserMembership() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+
+        String projectMembershipPayload = IOUtils.toString(TuleapApiClientTest.class.getResourceAsStream("project_membership_payload.json"), UTF_8.name());
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(404);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.string())
+            .thenReturn(projectMembershipPayload);
+
+        UserGroup userMembership1 = new UserGroupEntity("project_members", new ProjectEntity("coincoin", 106));
+        UserGroup userMembership2 = new UserGroupEntity("atchoum", new ProjectEntity("git-test", 113));
+
+        List<UserGroup> expectedList = ImmutableList.of(userMembership1, userMembership2);
+
+        List<UserGroup> resultList = tuleapApiClient.getUserMembership(this.accessToken);
+
+        assertEquals(expectedList.get(0).getGroupName(), resultList.get(0).getGroupName());
+        assertEquals(expectedList.get(0).getProjectName(), resultList.get(0).getProjectName());
+
+        assertEquals(expectedList.get(1).getGroupName(), resultList.get(1).getGroupName());
+        assertEquals(expectedList.get(1).getProjectName(), resultList.get(1).getProjectName());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void itShouldThrowExceptionWhenTheResponseIsNotSuccessfulAtQueryingNewUserMembershipRoute() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(404);
+        when(response.isSuccessful()).thenReturn(false);
+
+        tuleapApiClient.getUserMembership(this.accessToken);
+    }
+
     @Test(expected = RuntimeException.class)
     public void itThrowsExceptionWhenTheUserGroupCannotBeRetrieved() throws IOException {
         Call call = mock(Call.class);

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/project_membership_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/project_membership_payload.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "106_3",
+    "uri": "user_groups/106_3",
+    "label": "Project members",
+    "users_uri": "user_groups/106_3/users",
+    "short_name": "project_members",
+    "key": "ugroup_project_members_name_key",
+    "project": {
+      "id": 106,
+      "uri": "projects/106",
+      "label": "coincoin",
+      "shortname": "coincoin",
+      "status": "active",
+      "access": "public",
+      "is_template": false
+    }
+  },
+  {
+    "id": "110",
+    "uri": "user_groups/110",
+    "label": "atchoum",
+    "users_uri": "user_groups/110/users",
+    "short_name": "atchoum",
+    "key": "atchoum",
+    "project": {
+      "id": 113,
+      "uri": "projects/113",
+      "label": "git-test",
+      "shortname": "git-test",
+      "status": "active",
+      "access": "private",
+      "is_template": true
+    }
+  }
+]


### PR DESCRIPTION
This is a part of [story #14018](https://tuleap.net/plugins/tracker/?aid=14018) have a central management of users and groups using oauth

The old way is now deprecated but still there to avoid some breaking change in the case where Tuleap is not updated.
Before test this patch you must update your Tuleap dev

