### PR TITLE
Add a workflow Step to send test results to TTM in Tuleap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>2.0.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.164.1</jenkins.version>
+        <jenkins.version>2.176.4</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Tuleap API Plugin</name>
@@ -45,7 +45,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
+                <artifactId>bom-2.176.x</artifactId>
                 <version>10</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -54,6 +54,11 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
                 <version>1.3.72</version>
+            </dependency>
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -67,6 +72,10 @@
                     <artifactId>credentials</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -91,6 +100,12 @@
             <groupId>com.auth0</groupId>
             <artifactId>jwks-rsa</artifactId>
             <version>0.13.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/TestCampaignApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/TestCampaignApi.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+import hudson.util.Secret;
+
+import java.util.List;
+
+public interface TestCampaignApi {
+    String TEST_CAMPAIGN_API = "/testmanagement_campaigns";
+
+    void sendTTMResults(String campaignId, String buildUrl, List<String> results, Secret token);
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
@@ -12,5 +12,6 @@ public class TuleapApiGuiceModule extends com.google.inject.AbstractModule {
         bind(UserApi.class).to(TuleapApiClient.class);
         bind(UserGroupsApi.class).to(TuleapApiClient.class);
         bind(ProjectApi.class).to(TuleapApiClient.class);
+        bind(TestCampaignApi.class).to(TuleapApiClient.class);
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendTTMResultsEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendTTMResultsEntity.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.List;
+
+@JsonRootName("automated_tests_results")
+public class SendTTMResultsEntity {
+    private final List<String> results;
+    private final String buildUrl;
+
+    public SendTTMResultsEntity(final String buildUrl, final List<String> results) {
+        this.results = results;
+        this.buildUrl = buildUrl;
+    }
+
+    @JsonGetter("junit_contents")
+    public List<String> getResults() {
+        return this.results;
+    }
+
+    @JsonGetter("build_url")
+    public String getBuildUrl() {
+        return this.buildUrl;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsRunner.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsRunner.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import io.jenkins.plugins.tuleap_api.client.TestCampaignApi;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TuleapSendTTMResultsRunner {
+    private final TestCampaignApi testCampaignApi;
+
+    @Inject
+    public TuleapSendTTMResultsRunner(final TestCampaignApi testCampaignApi) {
+        this.testCampaignApi = testCampaignApi;
+    }
+
+    public void run(
+        final TuleapAccessToken tuleapAccessToken,
+        final PrintStream logger,
+        final TuleapSendTTMResultsStep step,
+        final FilePath filePath,
+        final EnvVars envVars
+    ) throws Exception {
+        logger.println("Collecting all result files");
+        final List<String> results = Arrays.stream(filePath.list(step.getFilesPath()))
+            .map(path -> {
+                try {
+                    return path.readToString();
+                } catch (IOException | InterruptedException exception) {
+                    throw new RuntimeException(exception);
+                }
+            })
+            .collect(Collectors.toList());
+
+        logger.println("Sending results to Tuleap");
+        this.testCampaignApi.sendTTMResults(
+            step.getCampaignId(),
+            envVars.get("BUILD_URL"),
+            results,
+            tuleapAccessToken.getToken()
+        );
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
@@ -1,0 +1,133 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.jetbrains.annotations.NotNull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.*;
+
+public class TuleapSendTTMResultsStep extends Step {
+    private final transient String filesPath;
+    private final transient String campaignId;
+    private final transient String credentialId;
+
+    @DataBoundConstructor
+    public TuleapSendTTMResultsStep(
+        String filesPath,
+        String campaignId,
+        String credentialId
+    ) {
+        this.filesPath = filesPath;
+        this.campaignId = campaignId;
+        this.credentialId = credentialId;
+    }
+
+    public String getFilesPath() {
+        return filesPath;
+    }
+
+    public String getCampaignId() {
+        return campaignId;
+    }
+
+    public String getCredentialId() {
+        return credentialId;
+    }
+
+    @Override
+    public StepExecution start(StepContext stepContext) throws Exception {
+        return new Execution(stepContext, this);
+    }
+
+    public static class Execution extends SynchronousStepExecution<Void> {
+        private final static long serialVersionUID = 1L;
+        private final transient TuleapSendTTMResultsStep tuleapSendTTMResultsStep;
+        private final transient TuleapConfiguration tuleapConfiguration;
+        private final transient TuleapSendTTMResultsRunner tuleapSendTTMResultsRunner;
+        private final transient Run run;
+        private final transient PrintStream logger;
+        private final  TaskListener taskListener;
+        private final  FilePath filePath;
+        private final  EnvVars envVars;
+
+        protected Execution(StepContext context, TuleapSendTTMResultsStep tuleapSendTTMResultsStep) throws IOException, InterruptedException {
+            super(context);
+            this.tuleapSendTTMResultsStep = tuleapSendTTMResultsStep;
+            this.taskListener = context.get(TaskListener.class);
+            this.logger = taskListener.getLogger();
+            this.filePath = getContext().get(FilePath.class);
+            this.envVars = getContext().get(EnvVars.class);
+            this.run = getContext().get(Run.class);
+
+            final Injector injector = Guice.createInjector(new TuleapApiGuiceModule());
+            this.tuleapSendTTMResultsRunner = injector.getInstance(TuleapSendTTMResultsRunner.class);
+            this.tuleapConfiguration = TuleapConfiguration.get();
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            assert filePath != null;
+
+            logger.println("Retrieving Tuleap API credentials");
+            final TuleapAccessToken tuleapAccessToken = CredentialsProvider.findCredentialById(
+                tuleapSendTTMResultsStep.getCredentialId(),
+                TuleapAccessToken.class,
+                run,
+                URIRequirementBuilder.fromUri(tuleapConfiguration.getApiBaseUrl()).build()
+            );
+
+            assert tuleapAccessToken != null;
+
+            tuleapSendTTMResultsRunner.run(
+                tuleapAccessToken,
+                logger,
+                tuleapSendTTMResultsStep,
+                filePath,
+                envVars
+            );
+
+            return null;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return new HashSet<>(
+                Arrays.asList(
+                    TaskListener.class,
+                    FilePath.class,
+                    EnvVars.class,
+                    Run.class
+                )
+            );
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "TuleapSendTTMResults";
+        }
+
+        @NotNull
+        @Override
+        public String getDisplayName() {
+            return "Send Tuleap Test Management Results";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
@@ -121,7 +121,7 @@ public class TuleapSendTTMResultsStep extends Step {
 
         @Override
         public String getFunctionName() {
-            return "TuleapSendTTMResults";
+            return "tuleapSendTTMResults";
         }
 
         @NotNull

--- a/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsRunnerTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsRunnerTest.java
@@ -1,0 +1,59 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.util.Secret;
+import io.jenkins.plugins.tuleap_api.client.TestCampaignApi;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import org.junit.Test;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class TuleapSendTTMResultsRunnerTest {
+
+    @Test
+    public void itSendsResultsToTTM() throws Exception {
+        final TestCampaignApi testCampaignApi = mock(TestCampaignApi.class);
+        final TuleapSendTTMResultsRunner tuleapSendTTMResultsRunner = new TuleapSendTTMResultsRunner(testCampaignApi);
+        final TuleapAccessToken tuleapAccessToken = mock(TuleapAccessToken.class);
+        final PrintStream logger = mock(PrintStream.class);
+        final TuleapSendTTMResultsStep tuleapSendTTMResultsStep = mock(TuleapSendTTMResultsStep.class);
+        final FilePath filePath = mock(FilePath.class);
+        final EnvVars envVars = mock(EnvVars.class);
+
+        final String path = "test/*.xml";
+        final String campaignId = "1";
+        final String buildUrl = "https://jenkins.example.com";
+        final Secret secret = Secret.fromString("a-very-secret-secret");
+        final List<String> results = Arrays.asList("some result 1", "some result 2");
+        final FilePath path1 = mock(FilePath.class);
+        final FilePath path2 = mock(FilePath.class);
+
+        when(tuleapSendTTMResultsStep.getCampaignId()).thenReturn(campaignId);
+        when(tuleapSendTTMResultsStep.getFilesPath()).thenReturn(path);
+        when(tuleapAccessToken.getToken()).thenReturn(secret);
+        when(envVars.get("BUILD_URL")).thenReturn(buildUrl);
+        when(path1.readToString()).thenReturn("some result 1");
+        when(path2.readToString()).thenReturn("some result 2");
+        when(filePath.list(path)).thenReturn(new FilePath[] {path1, path2});
+
+        tuleapSendTTMResultsRunner.run(
+            tuleapAccessToken,
+            logger,
+            tuleapSendTTMResultsStep,
+            filePath,
+            envVars
+        );
+
+        verify(testCampaignApi, atMostOnce()).sendTTMResults(
+            campaignId,
+            buildUrl,
+            results,
+            secret
+        );
+    }
+}


### PR DESCRIPTION
This change is part of [request #16216](https://tuleap.net/plugins/tracker/?aid=16216)

In order to test this new feature you need to create a JenkinsFile in a
repository of yours and you should be able to add:

```groovy
TuleapSendTTMResults filesPath: 'pouet/*.xml', campaignId: '1', credentialId: '484ed1cb-be32-418a-9a92-7d5dbaf7858d'
```