### PR TITLE
Add a step to automate build feedback from jenkins to Tuleap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <exclusions>
                 <exclusion>

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+import hudson.util.Secret;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.BuildStatus;
+
+public interface GitApi {
+    String GIT_API = "/git";
+    String STATUSES = "/statuses";
+
+    void sendBuildStatus(String repositoryId, String commitReference, BuildStatus status, Secret token);
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
@@ -13,5 +13,6 @@ public class TuleapApiGuiceModule extends com.google.inject.AbstractModule {
         bind(UserGroupsApi.class).to(TuleapApiClient.class);
         bind(ProjectApi.class).to(TuleapApiClient.class);
         bind(TestCampaignApi.class).to(TuleapApiClient.class);
+        bind(GitApi.class).to(TuleapApiClient.class);
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/BuildStatus.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/BuildStatus.java
@@ -1,0 +1,6 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+public enum BuildStatus {
+    failure,
+    success
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendBuildStatusEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendBuildStatusEntity.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+
+public class SendBuildStatusEntity {
+    private final String status;
+    private final String token;
+
+    public SendBuildStatusEntity(final String status, final String token) {
+        this.status = status;
+        this.token = token;
+    }
+
+    @JsonGetter("state")
+    public String getStatus() {
+        return status;
+    }
+
+    @JsonGetter("token")
+    public String getToken() {
+        return token;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import hudson.model.Run;
+import hudson.plugins.git.util.BuildData;
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import javax.inject.Inject;
+import java.io.PrintStream;
+
+public class TuleapNotifyCommitStatusRunner {
+    private final GitApi gitApi;
+
+    @Inject
+    public TuleapNotifyCommitStatusRunner(final GitApi gitApi) {
+        this.gitApi = gitApi;
+    }
+
+    public void run(
+        final StringCredentials credential,
+        final PrintStream logger,
+        final Run run,
+        final TuleapNotifyCommitStatusStep step
+    ) {
+        logger.println("Retrieving Git Data");
+        final BuildData gitData = run.getAction(BuildData.class);
+
+        assert gitData != null;
+
+        logger.println("Sending build status to Tuleap");
+        gitApi.sendBuildStatus(
+            step.getRepositoryId(),
+            gitData.lastBuild.getSHA1().name(),
+            step.getStatus(),
+            credential.getSecret()
+        );
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
@@ -1,0 +1,115 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.tuleap_api.client.TuleapApiGuiceModule;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.BuildStatus;
+import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TuleapNotifyCommitStatusStep extends Step {
+    private final BuildStatus status;
+    private final String repositoryId;
+    private final String credentialId;
+
+    @DataBoundConstructor
+    public TuleapNotifyCommitStatusStep(BuildStatus status, String repositoryId, String credentialId) {
+        this.status = status;
+        this.repositoryId = repositoryId;
+        this.credentialId = credentialId;
+    }
+
+    public BuildStatus getStatus() {
+        return status;
+    }
+
+    public String getCredentialId() {
+        return credentialId;
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new TuleapNotifyCommitStatusStepExecution(context, this);
+    }
+
+    public static class TuleapNotifyCommitStatusStepExecution extends SynchronousStepExecution<Void> {
+        private static final long serialVersionUID = 1L;
+        private final transient Run<?, ?> run;
+        private final transient TuleapNotifyCommitStatusStep step;
+        private final transient PrintStream logger;
+        private final transient TuleapConfiguration tuleapConfiguration;
+        private final transient TuleapNotifyCommitStatusRunner tuleapNotifyCommitStatusRunner;
+
+        TuleapNotifyCommitStatusStepExecution(StepContext context, TuleapNotifyCommitStatusStep tuleapNotifyCommitStatusStep) throws Exception {
+            super(context);
+            this.step = tuleapNotifyCommitStatusStep;
+            run = getContext().get(Run.class);
+            logger = getContext().get(TaskListener.class).getLogger();
+
+            final Injector injector = Guice.createInjector(new TuleapApiGuiceModule());
+            this.tuleapNotifyCommitStatusRunner = injector.getInstance(TuleapNotifyCommitStatusRunner.class);
+            this.tuleapConfiguration = TuleapConfiguration.get();
+        }
+
+        @Override
+        protected Void run() {
+            logger.println("Retrieving Tuleap API credentials");
+            final StringCredentials credential = CredentialsProvider.findCredentialById(
+                step.getCredentialId(),
+                StringCredentials.class,
+                run,
+                URIRequirementBuilder.fromUri(tuleapConfiguration.getApiBaseUrl()).build()
+            );
+
+            assert credential != null;
+
+            tuleapNotifyCommitStatusRunner.run(
+                credential,
+                logger,
+                run,
+                step
+            );
+
+            return null;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Update the build status of the commit in Tuleap";
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "tuleapNotifyCommitStatus";
+        }
+
+        @Override
+        public Set<Class<?>> getRequiredContext() {
+            return new HashSet<>(
+                Arrays.asList(
+                    TaskListener.class,
+                    Run.class
+                )
+            );
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.tuleap_api.steps;
+
+import hudson.model.Run;
+import hudson.plugins.git.util.Build;
+import hudson.plugins.git.util.BuildData;
+import hudson.util.Secret;
+import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.internals.entities.BuildStatus;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.Test;
+
+import java.io.PrintStream;
+
+import static org.mockito.Mockito.*;
+
+public class TuleapNotifyCommitStatusRunnerTest {
+
+    @Test
+    public void itSendsCommitBuildResultToTuleap() throws Exception {
+        final GitApi gitApi = mock(GitApi.class);
+        final TuleapNotifyCommitStatusRunner tuleapNotifyCommitStatusRunner = new TuleapNotifyCommitStatusRunner(gitApi);
+        final StringCredentials credential = mock(StringCredentials.class);
+        final PrintStream logger = mock(PrintStream.class);
+        final TuleapNotifyCommitStatusStep tuleapNotifyCommitStatusStep = mock(TuleapNotifyCommitStatusStep.class);
+        final Run run = mock(Run.class);
+        final BuildData buildData = mock(BuildData.class);
+        final Build build = mock(Build.class);
+        final ObjectId sha1 = mock(ObjectId.class);
+
+        final String repositoryId = "1";
+        final String aSha1Value = "someSha1ValueThatMatters";
+        final Secret secret = Secret.fromString("a-very-secret-secret");
+
+        buildData.lastBuild = build;
+        when(tuleapNotifyCommitStatusStep.getRepositoryId()).thenReturn(repositoryId);
+        when(tuleapNotifyCommitStatusStep.getStatus()).thenReturn(BuildStatus.success);
+        when(run.getAction(BuildData.class)).thenReturn(buildData);
+        when(build.getSHA1()).thenReturn(sha1);
+        when(sha1.name()).thenReturn(aSha1Value);
+        when(credential.getSecret()).thenReturn(secret);
+
+        tuleapNotifyCommitStatusRunner.run(
+            credential,
+            logger,
+            run,
+            tuleapNotifyCommitStatusStep
+        );
+
+        verify(gitApi, atMostOnce()).sendBuildStatus(
+            repositoryId,
+            aSha1Value,
+            BuildStatus.success,
+            secret
+        );
+    }
+}


### PR DESCRIPTION
This change is part of [request #14430](https://tuleap.net/plugins/tracker/?aid=14430)

In order to test this new feature, you need to create a JenkinsFile in a
repository of yours and you should add something like:

```groovy
tuleapNotifyCommitStatus status: 'success', repositoryId: '1', credentialId: 'e13cd316-88ac-4050-8c82-d0fb9403f030'
```

Please, beware that the credentialId used **must** be of type Secret text.