### PR TITLE
Add pending status for TuleapNotifyCommitStatusStep

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/TuleapBuildStatus.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/TuleapBuildStatus.java
@@ -2,5 +2,6 @@ package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
 public enum TuleapBuildStatus {
     failure,
-    success
+    success,
+    pending
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
@@ -131,6 +131,7 @@ public class TuleapNotifyCommitStatusStep extends Step {
             ListBoxModel options = new ListBoxModel();
             options.add(Messages.TuleapNotifyCommitStatusStep_success(), TuleapBuildStatus.success.name());
             options.add(Messages.TuleapNotifyCommitStatusStep_failure(), TuleapBuildStatus.failure.name());
+            options.add(Messages.TuleapNotifyCommitStatusStep_pending(), TuleapBuildStatus.pending.name());
             return options;
         }
 

--- a/src/main/resources/io/jenkins/plugins/tuleap_api/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/tuleap_api/Messages.properties
@@ -1,5 +1,6 @@
 TuleapNotifyCommitStatusStep.displayName = Update the build status of the commit in Tuleap
 TuleapNotifyCommitStatusStep.success = Success
 TuleapNotifyCommitStatusStep.failure = Failure
+TuleapNotifyCommitStatusStep.pending = Pending
 
 TuleapSendTTMResultsStep.displayName = Send Tuleap Test Management results

--- a/src/main/resources/io/jenkins/plugins/tuleap_api/Messages_fr.properties
+++ b/src/main/resources/io/jenkins/plugins/tuleap_api/Messages_fr.properties
@@ -1,5 +1,6 @@
 TuleapNotifyCommitStatusStep.displayName = Met à jour le statut du build d'un commit dans Tuleap
 TuleapNotifyCommitStatusStep.success = Succès
 TuleapNotifyCommitStatusStep.failure = Echec
+TuleapNotifyCommitStatusStep.pending = En attente
 
 TuleapSendTTMResultsStep.displayName = Envoie à Tuleap les resultats de Test Management


### PR DESCRIPTION
Now it is possible to change the status of a commit with the status
`Pending`

part of: [story #18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

How to test:

1. In your Jenkinsfile, in one of your steps, add:

`tuleapNotifyCommitStatus status: 'pending', repositoryId: '<id>', credentialId: '<tuleap-ci-token>'`

2. Trigger a job using this Jenkinsfile

--> The status Pending is set by Jenkins on the target commit (see
pullrequest plugin UI)

Also, the option `Pending` for the selectbox in the pipeline edition GUI
should appear.