### PR TITLE
Send build status using an access key

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -1,11 +1,14 @@
 package io.jenkins.plugins.tuleap_api.client;
 
-import hudson.util.Secret;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public interface GitApi {
     String GIT_API = "/git";
     String STATUSES = "/statuses";
 
-    void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, Secret token);
+    void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
+
+    void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -12,8 +12,10 @@ import io.jenkins.plugins.tuleap_api.client.authentication.AccessToken;
 import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.*;
 import io.jenkins.plugins.tuleap_api.client.internals.exceptions.InvalidTuleapResponseException;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
 import okhttp3.*;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -287,13 +289,36 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
     }
 
     @Override
-    public void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, Secret token) {
+    public void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials) {
         Request request;
 
         try {
             request = new Request.Builder()
                 .url(this.tuleapConfiguration.getApiBaseUrl() + this.GIT_API + "/" + repositoryId + this.STATUSES + "/" + commitReference )
-                .post(RequestBody.create(this.objectMapper.writeValueAsString(new SendBuildStatusEntity(status.name(), token.getPlainText())), JSON))
+                .post(RequestBody.create(this.objectMapper.writeValueAsString(new SendBuildStatusAndCITokenEntity(status.name(), credentials.getSecret().getPlainText())), JSON))
+                .build();
+        } catch (JsonProcessingException exception) {
+            throw new RuntimeException("Error while trying to create request for build status", exception);
+        }
+
+        try (Response response = this.client.newCall(request).execute()) {
+            if (! response.isSuccessful()) {
+                throw new InvalidTuleapResponseException(response);
+            }
+        } catch (IOException | InvalidTuleapResponseException exception) {
+            throw new RuntimeException("Error while contacting Tuleap server", exception);
+        }
+    }
+
+    @Override
+    public void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token) {
+        Request request;
+
+        try {
+            request = new Request.Builder()
+                .url(this.tuleapConfiguration.getApiBaseUrl() + this.GIT_API + "/" + repositoryId + this.STATUSES + "/" + commitReference)
+                .addHeader(this.AUTHORIZATION_HEADER, token.getToken().getPlainText())
+                .post(RequestBody.create(this.objectMapper.writeValueAsString(new SendBuildStatusEntity(status.name())), JSON))
                 .build();
         } catch (JsonProcessingException exception) {
             throw new RuntimeException("Error while trying to create request for build status", exception);

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendBuildStatusAndCITokenEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/SendBuildStatusAndCITokenEntity.java
@@ -2,15 +2,22 @@ package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
-public class SendBuildStatusEntity {
+public class SendBuildStatusAndCITokenEntity {
     private final String status;
+    private final String token;
 
-    public SendBuildStatusEntity(final String status) {
+    public SendBuildStatusAndCITokenEntity(final String status, final String token) {
         this.status = status;
+        this.token = token;
     }
 
     @JsonGetter("state")
     public String getStatus() {
         return status;
+    }
+
+    @JsonGetter("token")
+    public String getToken() {
+        return token;
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
@@ -37,7 +37,7 @@ public class TuleapNotifyCommitStatusRunner {
             step.getRepositoryId(),
             gitData.lastBuild.getSHA1().name(),
             step.getStatus(),
-            credential.getSecret()
+            credential
         );
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
@@ -5,6 +5,7 @@ import hudson.plugins.git.util.BuildData;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import java.io.PrintStream;
@@ -23,14 +24,7 @@ public class TuleapNotifyCommitStatusRunner {
         final Run run,
         final TuleapNotifyCommitStatusStep step
     ) {
-        logger.println("Retrieving Git Data");
-        final BuildData gitData = run.getAction(BuildData.class);
-
-        if (gitData == null) {
-            throw new RuntimeException(
-                "Failed to retrieve Git Data. Please check the configuration."
-            );
-        }
+        final BuildData gitData = retrieveGitData(logger, run);
 
         logger.println("Sending build status to Tuleap");
         gitApi.sendBuildStatus(
@@ -39,5 +33,35 @@ public class TuleapNotifyCommitStatusRunner {
             step.getStatus(),
             credential
         );
+    }
+
+    public void run(
+        final TuleapAccessToken accessKey,
+        final PrintStream logger,
+        final Run run,
+        final TuleapNotifyCommitStatusStep step
+    ) {
+        final BuildData gitData = retrieveGitData(logger, run);
+
+        logger.println("Sending build status to Tuleap");
+        gitApi.sendBuildStatus(
+            step.getRepositoryId(),
+            gitData.lastBuild.getSHA1().name(),
+            step.getStatus(),
+            accessKey
+        );
+    }
+
+    @NotNull
+    private BuildData retrieveGitData(PrintStream logger, Run run) {
+        logger.println("Retrieving Git Data");
+        final BuildData gitData = run.getAction(BuildData.class);
+
+        if (gitData == null) {
+            throw new RuntimeException(
+                "Failed to retrieve Git Data. Please check the configuration."
+            );
+        }
+        return gitData;
     }
 }

--- a/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
@@ -3,9 +3,9 @@ package io.jenkins.plugins.tuleap_api.steps;
 import hudson.model.Run;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
-import hudson.util.Secret;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.junit.Test;
@@ -17,10 +17,47 @@ import static org.mockito.Mockito.*;
 public class TuleapNotifyCommitStatusRunnerTest {
 
     @Test
-    public void itSendsCommitBuildResultToTuleap() throws Exception {
+    public void itSendsCommitBuildResultToTuleapUsingCIToken() {
         final GitApi gitApi = mock(GitApi.class);
         final TuleapNotifyCommitStatusRunner tuleapNotifyCommitStatusRunner = new TuleapNotifyCommitStatusRunner(gitApi);
         final StringCredentials credential = mock(StringCredentials.class);
+        final PrintStream logger = mock(PrintStream.class);
+        final TuleapNotifyCommitStatusStep tuleapNotifyCommitStatusStep = mock(TuleapNotifyCommitStatusStep.class);
+        final Run run = mock(Run.class);
+        final BuildData buildData = mock(BuildData.class);
+        final Build build = mock(Build.class);
+        final ObjectId sha1 = mock(ObjectId.class);
+
+        final String repositoryId = "1";
+        final String aSha1Value = "someSha1ValueThatMatters";
+
+        buildData.lastBuild = build;
+        when(tuleapNotifyCommitStatusStep.getRepositoryId()).thenReturn(repositoryId);
+        when(tuleapNotifyCommitStatusStep.getStatus()).thenReturn(TuleapBuildStatus.success);
+        when(run.getAction(BuildData.class)).thenReturn(buildData);
+        when(build.getSHA1()).thenReturn(sha1);
+        when(sha1.name()).thenReturn(aSha1Value);
+
+        tuleapNotifyCommitStatusRunner.run(
+            credential,
+            logger,
+            run,
+            tuleapNotifyCommitStatusStep
+        );
+
+        verify(gitApi, atMostOnce()).sendBuildStatus(
+            repositoryId,
+            aSha1Value,
+            TuleapBuildStatus.success,
+            credential
+        );
+    }
+
+    @Test
+    public void itSendsCommitBuildResultToTuleapUsingAccessKey() {
+        final GitApi gitApi = mock(GitApi.class);
+        final TuleapNotifyCommitStatusRunner tuleapNotifyCommitStatusRunner = new TuleapNotifyCommitStatusRunner(gitApi);
+        final TuleapAccessToken credential = mock(TuleapAccessToken.class);
         final PrintStream logger = mock(PrintStream.class);
         final TuleapNotifyCommitStatusStep tuleapNotifyCommitStatusStep = mock(TuleapNotifyCommitStatusStep.class);
         final Run run = mock(Run.class);

--- a/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunnerTest.java
@@ -30,7 +30,6 @@ public class TuleapNotifyCommitStatusRunnerTest {
 
         final String repositoryId = "1";
         final String aSha1Value = "someSha1ValueThatMatters";
-        final Secret secret = Secret.fromString("a-very-secret-secret");
 
         buildData.lastBuild = build;
         when(tuleapNotifyCommitStatusStep.getRepositoryId()).thenReturn(repositoryId);
@@ -38,7 +37,6 @@ public class TuleapNotifyCommitStatusRunnerTest {
         when(run.getAction(BuildData.class)).thenReturn(buildData);
         when(build.getSHA1()).thenReturn(sha1);
         when(sha1.name()).thenReturn(aSha1Value);
-        when(credential.getSecret()).thenReturn(secret);
 
         tuleapNotifyCommitStatusRunner.run(
             credential,
@@ -51,7 +49,7 @@ public class TuleapNotifyCommitStatusRunnerTest {
             repositoryId,
             aSha1Value,
             TuleapBuildStatus.success,
-            secret
+            credential
         );
     }
 


### PR DESCRIPTION
The goal of this patch is to allow calls to
`/git/:id_or_path/statuses/:commit_reference` using an access key (passed
in the headers) in addition to the usage of the CIToken.

part of: [request #18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

## How to test:
1. In a Jenkinsfile where you are using TuleapNotifyCommitStatusSteps, pick up two steps
2. On the first one, pass the id of a ci token in its parameters
3. On the second one, give the id of an access key in its parameters
4. Run the job

-> Tuleap is notified for both steps even if they use different credentials types

