### PR TITLE
Add the support of the route which retrieve a git commit information

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -6,9 +6,13 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public interface GitApi {
     String GIT_API = "/git";
+
     String STATUSES = "/statuses";
+    String COMMITS = "/commits";
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
+
+    GitCommit getCommit(String repositoryId, String commitReference, TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitCommit.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitCommit.java
@@ -1,0 +1,9 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+import java.time.ZonedDateTime;
+
+public interface GitCommit {
+    String getHash();
+
+    ZonedDateTime getCommitDate();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/TuleapApiGuiceModule.java
@@ -1,6 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jenkins.plugins.tuleap_api.client.internals.TuleapApiClient;
+import io.jenkins.plugins.tuleap_api.client.internals.guice.ObjectMapperProvider;
 import io.jenkins.plugins.tuleap_api.client.internals.guice.OkHttpClientProvider;
 import okhttp3.OkHttpClient;
 
@@ -8,6 +10,7 @@ public class TuleapApiGuiceModule extends com.google.inject.AbstractModule {
     @Override
     protected void configure() {
         bind(OkHttpClient.class).toProvider(OkHttpClientProvider.class).asEagerSingleton();
+        bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class);
         bind(AccessKeyApi.class).to(TuleapApiClient.class);
         bind(UserApi.class).to(TuleapApiClient.class);
         bind(UserGroupsApi.class).to(TuleapApiClient.class);

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/AccessKeyEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/AccessKeyEntity.java
@@ -1,13 +1,11 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AccessKeyEntity {
     private List<AccessKeyScopeEntity> scopes;
 

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/AccessKeyScopeEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/AccessKeyScopeEntity.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.AccessKeyScope;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AccessKeyScopeEntity implements AccessKeyScope {
     private String identifier;
 

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitCommitEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitCommitEntity.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitCommit;
+
+import java.time.ZonedDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitCommitEntity implements GitCommit {
+
+    private final String hash;
+
+    private final ZonedDateTime commitDate;
+
+    public GitCommitEntity(@JsonProperty("id") String hash, @JsonProperty("committed_date") String commitDate) {
+        this.hash = hash;
+        this.commitDate = ZonedDateTime.parse(commitDate);
+    }
+
+    @Override
+    public String getHash() {
+        return this.hash;
+    }
+
+    @Override
+    public ZonedDateTime getCommitDate() {
+        return this.commitDate;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitCommitEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitCommitEntity.java
@@ -1,12 +1,10 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.GitCommit;
 
 import java.time.ZonedDateTime;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class GitCommitEntity implements GitCommit {
 
     private final String hash;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/MinimalUserGroupEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/MinimalUserGroupEntity.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.UserGroup;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class MinimalUserGroupEntity implements UserGroup {
 
     private String shortName;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/ProjectEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/ProjectEntity.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.Project;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectEntity implements Project {
 
     private String shortname;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/UserEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/UserEntity.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.User;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserEntity implements User {
     private String username;
 

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/UserGroupEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/UserGroupEntity.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.tuleap_api.client.internals.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.plugins.tuleap_api.client.UserGroup;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserGroupEntity implements UserGroup {
 
     private String shortName;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/guice/ObjectMapperProvider.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/guice/ObjectMapperProvider.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.tuleap_api.client.internals.guice;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Provider;
+
+public class ObjectMapperProvider implements Provider<ObjectMapper> {
+
+    @Override
+    public ObjectMapper get() {
+        return new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.tuleap_api.client.internals;
 
 import com.cloudbees.plugins.credentials.CredentialsDescriptor;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.util.Secret;
 import io.jenkins.plugins.tuleap_api.client.GitCommit;
@@ -48,7 +49,7 @@ public class TuleapApiClientTest {
     public void setUp() {
         client = mock(OkHttpClient.class);
         tuleapConfiguration = mock(TuleapConfiguration.class);
-        mapper = new ObjectMapper();
+        mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         tuleapApiClient = new TuleapApiClient(tuleapConfiguration, client, mapper);
         secret = mock(Secret.class);
 

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_commit_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_commit_payload.json
@@ -1,0 +1,15 @@
+{
+  "id": "38dfa09a67d7872d821b6a46eff340bc8ae0af0f",
+  "author_name": "Coco L'Asticot",
+  "authored_date": "2021-01-07T14:58:40+01:00",
+  "committed_date": "2021-01-07T14:58:40+01:00",
+  "title": "Tonight! in some emission",
+  "message": "I wear a hat, my colleague wears a hat, and the third wears a yellow hat",
+  "author_email": "asticotc@example.com",
+  "author": "Coco L'Ascticot",
+  "html_url": "/plugins/git/alm/repo001?a=commit&h=38dfa09a67d7872d821b6a46eff340bc8ae0af0f",
+  "commit_status": null,
+  "verification": {
+    "signature": null
+  }
+}


### PR DESCRIPTION
Part of [story #18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch
source jenkins plugin

This patch the support of GET `/git/:repo_id/commits/:commit_reference`
route
