### PR TITLE
Log a warning instead of cutting job execution when commit notification is sent

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -14,8 +14,6 @@ public interface GitApi {
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
 
-    void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
-
     void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
 
     GitCommit getCommit(String repositoryId, String commitReference, TuleapAccessToken token);

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -14,5 +14,9 @@ public interface GitApi {
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
 
+    void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
+
+    void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
+
     GitCommit getCommit(String repositoryId, String commitReference, TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -335,28 +335,6 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
     }
 
     @Override
-    public void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials) {
-        Request request;
-
-        try {
-            request = new Request.Builder()
-                .url(this.tuleapConfiguration.getApiBaseUrl() + this.GIT_API + "/" + repositoryId + this.STATUSES + "/" + commitReference )
-                .post(RequestBody.create(this.objectMapper.writeValueAsString(new SendBuildStatusAndCITokenEntity(status.name(), credentials.getSecret().getPlainText())), JSON))
-                .build();
-        } catch (JsonProcessingException exception) {
-            throw new RuntimeException("Error while trying to create request for build status", exception);
-        }
-
-        try (Response response = this.client.newCall(request).execute()) {
-            if (! response.isSuccessful()) {
-                LOGGER.log(Level.WARNING, "The response received from Tuleap is invalid: {0}", response.toString());
-            }
-        } catch (IOException exception) {
-            throw new RuntimeException("Error while contacting Tuleap server", exception);
-        }
-    }
-
-    @Override
     public void sendBuildStatusWithWarningLog(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token) {
         Request request;
 

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserApi, UserGroupsApi, ProjectApi , TestCampaignApi, GitApi {
@@ -303,9 +304,9 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
 
         try (Response response = this.client.newCall(request).execute()) {
             if (! response.isSuccessful()) {
-                throw new InvalidTuleapResponseException(response);
+                LOGGER.log(Level.WARNING, "The response received from Tuleap is invalid: {0}", response.toString());
             }
-        } catch (IOException | InvalidTuleapResponseException exception) {
+        } catch (IOException exception) {
             throw new RuntimeException("Error while contacting Tuleap server", exception);
         }
     }
@@ -326,9 +327,9 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
 
         try (Response response = this.client.newCall(request).execute()) {
             if (!response.isSuccessful()) {
-                throw new InvalidTuleapResponseException(response);
+                LOGGER.log(Level.WARNING, "The response received from Tuleap is invalid: {0}", response.toString());
             }
-        } catch (IOException | InvalidTuleapResponseException exception) {
+        } catch (IOException exception) {
             throw new RuntimeException("Error while contacting Tuleap server", exception);
         }
     }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusRunner.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.tuleap_api.steps;
 import hudson.model.Run;
 import hudson.plugins.git.util.BuildData;
 import io.jenkins.plugins.tuleap_api.client.GitApi;
+import io.jenkins.plugins.tuleap_api.client.GitCommit;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -443,7 +443,6 @@ public class TuleapApiClientTest {
         when(response.isSuccessful()).thenReturn(true);
 
         tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, tuleapAccessToken);
-        tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, stringCredentials);
     }
 
     @Test
@@ -459,22 +458,6 @@ public class TuleapApiClientTest {
         when(response.isSuccessful()).thenReturn(true);
 
         tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, tuleapAccessToken);
-        tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, stringCredentials);
-    }
-
-    @Test
-    public void testItPostTheBuildResultWithoutErrorWhenTheResponseIsNotSuccessful() throws IOException {
-        TuleapAccessToken tuleapAccessToken = this.getTuleapAccessTokenStubClass();
-        StringCredentials stringCredentials = this.getStringCredentialsStubClass();
-        Call call = mock(Call.class);
-        Response response = mock(Response.class);
-
-        when(client.newCall(any())).thenReturn(call);
-        when(call.execute()).thenReturn(response);
-        when(response.isSuccessful()).thenReturn(false);
-
-        tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, tuleapAccessToken);
-        tuleapApiClient.sendBuildStatusWithWarningLog("10", "518151ezze", TuleapBuildStatus.success, stringCredentials);
     }
 
     private TuleapAccessToken getTuleapAccessTokenStubClass() {

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -434,7 +434,6 @@ public class TuleapApiClientTest {
     @Test
     public void testItPostTheBuildResult() throws IOException {
         TuleapAccessToken tuleapAccessToken = this.getTuleapAccessTokenStubClass();
-        StringCredentials stringCredentials = this.getStringCredentialsStubClass();
         Call call = mock(Call.class);
         Response response = mock(Response.class);
 
@@ -448,7 +447,6 @@ public class TuleapApiClientTest {
     @Test
     public void testItPostTheBuildResultWithoutErrorWhenTheResponseIsSuccessful() throws IOException {
         TuleapAccessToken tuleapAccessToken = this.getTuleapAccessTokenStubClass();
-        StringCredentials stringCredentials = this.getStringCredentialsStubClass();
 
         Call call = mock(Call.class);
         Response response = mock(Response.class);


### PR DESCRIPTION
 [request #21785](https://tuleap.net/plugins/tracker/?aid=21785) Errors on auto-notify should be printed but not taken into account as a failure

How to test:
     - Run a job which fails because of Tuleap REST API response
    => In the Jenkins Log, the error is displayed
    => The job still running until the end.
