### PR TITLE
Add the Git get file content and tree content routes

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -1,18 +1,28 @@
 package io.jenkins.plugins.tuleap_api.client;
 
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.FileContentNotFoundException;
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.TreeNotFoundException;
 import io.jenkins.plugins.tuleap_api.client.internals.entities.TuleapBuildStatus;
 import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import java.util.List;
 
 public interface GitApi {
     String GIT_API = "/git";
 
     String STATUSES = "/statuses";
     String COMMITS = "/commits";
+    String TREE = "/tree";
+    String FILES = "/files";
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, TuleapAccessToken token);
 
     GitCommit getCommit(String repositoryId, String commitReference, TuleapAccessToken token);
+
+    List<GitTreeContent> getTree(String repositoryId, String commitReference, String path, TuleapAccessToken token) throws TreeNotFoundException;
+
+    GitFileContent getFileContent(String repositoryId, String path, String commitReference, TuleapAccessToken token) throws FileContentNotFoundException;
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitFileContent.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitFileContent.java
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+public interface GitFileContent{
+    String getEncoding();
+
+    Integer getSize();
+
+    String getName();
+
+    String getPath();
+
+    String getContent();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitTreeContent.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitTreeContent.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+import io.jenkins.plugins.tuleap_api.client.exceptions.git.TreeNotFoundException;
+
+public interface GitTreeContent {
+
+    enum ContentType {
+        TREE,
+        BLOB,
+        SYMLINK;
+
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+    }
+
+    String getId();
+
+    String getName();
+
+    String getPath();
+
+    ContentType getType();
+
+    String getMode();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/ProjectNotFoundException.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/ProjectNotFoundException.java
@@ -1,7 +1,5 @@
 package io.jenkins.plugins.tuleap_api.client.exceptions;
 
-import okhttp3.Response;
-
 public class ProjectNotFoundException extends Exception {
     private final String projectShortname;
 

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/git/FileContentNotFoundException.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/git/FileContentNotFoundException.java
@@ -1,0 +1,4 @@
+package io.jenkins.plugins.tuleap_api.client.exceptions.git;
+
+public class FileContentNotFoundException extends Exception {
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/git/TreeNotFoundException.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/exceptions/git/TreeNotFoundException.java
@@ -1,0 +1,3 @@
+package io.jenkins.plugins.tuleap_api.client.exceptions.git;
+
+public class TreeNotFoundException extends Exception { }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitFileContentEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitFileContentEntity.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitFileContent;
+
+public class GitFileContentEntity implements GitFileContent {
+
+    private final String encoding;
+    private final Integer size;
+    private final String name;
+    private final String path;
+    private final String content;
+
+
+    public GitFileContentEntity(
+        @JsonProperty("encoding") String encoding,
+        @JsonProperty("size") Integer size,
+        @JsonProperty("name") String name,
+        @JsonProperty("path") String path,
+        @JsonProperty("content") String content
+    ) {
+        this.encoding = encoding;
+        this.size = size;
+        this.name = name;
+        this.content = content;
+        this.path = path;
+    }
+
+    @Override
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+    @Override
+    public Integer getSize() {
+        return this.size;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public String getContent() {
+        return this.content;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitTreeContentEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitTreeContentEntity.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+
+public class GitTreeContentEntity implements GitTreeContent {
+
+    private final String id;
+    private final String name;
+    private final String path;
+    private final ContentType type;
+    private final String mode;
+
+
+    public GitTreeContentEntity(
+        @JsonProperty("id") String id,
+        @JsonProperty("name") String name,
+        @JsonProperty("path") String path,
+        @JsonProperty("type") String type,
+        @JsonProperty("mode") String mode
+    ) {
+        this.id = id;
+        this.name = name;
+        this.path = path;
+        this.mode = mode;
+        this.type = getComputedType(type);
+    }
+
+    private ContentType getComputedType(String type) {
+        if ("tree".equals(type)) {
+            return ContentType.TREE;
+        }
+
+        if ("120000".equals(this.mode)) {
+            return ContentType.SYMLINK;
+        }
+
+        return ContentType.BLOB;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public ContentType getType() {
+        return type;
+    }
+
+    @Override
+    public String getMode() {
+        return mode;
+    }
+}

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitTreeContentEntityTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitTreeContentEntityTest.java
@@ -1,0 +1,43 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import io.jenkins.plugins.tuleap_api.client.GitTreeContent;
+import junit.framework.TestCase;
+
+public class GitTreeContentEntityTest extends TestCase {
+
+    public void testItSetsGitTreeContentTypeToTreeIfTree() {
+        GitTreeContent content = new GitTreeContentEntity(
+            "whatever_id",
+            "whatever_name",
+            "whatever_path",
+            "tree",
+            "whatever_mode"
+        );
+
+        assertEquals(GitTreeContent.ContentType.TREE, content.getType());
+    }
+
+    public void testItSetsGitTreeContentTypeToSymlinkIfNotTreeAnd120000Mode() {
+        GitTreeContent content = new GitTreeContentEntity(
+            "whatever_id",
+            "whatever_name",
+            "whatever_path",
+            "blob",
+            "120000"
+        );
+
+        assertEquals(GitTreeContent.ContentType.SYMLINK, content.getType());
+    }
+
+    public void testItSetsGitTreeContentTypeToBlobOtherwise() {
+        GitTreeContent content = new GitTreeContentEntity(
+            "whatever_id",
+            "whatever_name",
+            "whatever_path",
+            "blob",
+            "whatever_mode"
+        );
+
+        assertEquals(GitTreeContent.ContentType.BLOB, content.getType());
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_file_content_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_file_content_payload.json
@@ -1,0 +1,7 @@
+{
+  "encoding": "base64",
+  "size": 10,
+  "name": "Naha",
+  "path": "TwoBro/Naha",
+  "content": "cGlwZWxpbmUgewog=="
+}

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_tree_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_tree_payload.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "1c9c91a94db210c1f686dfd5d67f81813e02647b",
+    "name": "Jenkinsfile",
+    "path": "Jenkinsfile",
+    "type": "blob",
+    "mode": "100644"
+  },
+  {
+    "id": "706530ef3efed3fe242033d0458c28707a19a3ec",
+    "name": "README",
+    "path": "README",
+    "type": "blob",
+    "mode": "120000"
+  },
+  {
+    "id": "699b379c93fbd7fc3c0b175ff7960ee9a475b1b6",
+    "name": "doc",
+    "path": "doc",
+    "type": "tree",
+    "mode": "040000"
+  }
+]


### PR DESCRIPTION
Part of [story#18320](https://tuleap.net/plugins/tracker/?aid=18320) native support of pull requests in tuleap branch source jenkins plugin

Add the support of:
 - GET git/:id/files
 - GET git/:id/tree

These routes are needed to implement the FileSystem class in Tuleap Git
Branch Source plugin
