### PR TITLE
refacto: use the new API to retrieve the project by the project id

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/Project.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/Project.java
@@ -3,5 +3,11 @@ package io.jenkins.plugins.tuleap_api.client;
 public interface Project {
 
     Integer getId();
+
     String getShortname();
+
+    String getLabel();
+
+    String getUri();
+
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.tuleap_api.client;
 
 import io.jenkins.plugins.tuleap_api.client.authentication.AccessToken;
 import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
+import io.jenkins.plugins.tuleap_credentials.TuleapAccessToken;
 
 import java.util.List;
 
@@ -11,5 +12,6 @@ public interface ProjectApi {
     String PROJECT_GROUPS = "/user_groups";
 
     Project getProjectByShortname(String shortname, AccessToken token) throws ProjectNotFoundException;
+    Project getProjectById(String projectId, TuleapAccessToken token) ;
     List<UserGroup> getProjectUserGroups(Integer projectId, AccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -248,6 +248,29 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
 
     @Override
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
+    public Project getProjectById(String projectId, TuleapAccessToken token) {
+        final Request request = new Request.Builder()
+            .url(this.tuleapConfiguration.getApiBaseUrl() + this.PROJECT_API + "/" + projectId)
+            .addHeader(this.AUTHORIZATION_HEADER, token.getToken().getPlainText())
+            .get()
+            .build();
+
+        try (final Response response = this.client.newCall(request).execute()) {
+            if (! response.isSuccessful()) {
+                throw new InvalidTuleapResponseException(response);
+            }
+
+            return this.objectMapper.readValue(
+                Objects.requireNonNull(response.body()).string(),
+                ProjectEntity.class
+            );
+        } catch (IOException | InvalidTuleapResponseException e) {
+            throw new RuntimeException("Error while contacting Tuleap server", e);
+        }
+    }
+
+    @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
     public List<UserGroup> getProjectUserGroups(Integer projectId, AccessToken token) {
         final Request request = new Request.Builder()
             .url(this.tuleapConfiguration.getApiBaseUrl() + this.PROJECT_API + "/" + projectId + this.PROJECT_GROUPS)

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/ProjectEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/ProjectEntity.java
@@ -7,17 +7,33 @@ public class ProjectEntity implements Project {
 
     private String shortname;
     private Integer id;
+    private final String uri;
+    private final String label;
 
     public ProjectEntity(
         @JsonProperty("shortname") String shortname,
-        @JsonProperty("id") Integer id
-    ){
+        @JsonProperty("id") Integer id,
+        @JsonProperty("uri") String uri,
+        @JsonProperty("label") String label
+    ) {
         this.shortname = shortname;
         this.id = id;
+        this.uri = uri;
+        this.label = label;
     }
 
     public String getShortname() {
         return this.shortname;
+    }
+
+    @Override
+    public String getUri() {
+        return this.uri;
+    }
+
+    @Override
+    public String getLabel() {
+        return this.label;
     }
 
     public Integer getId() {

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/single_project_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/single_project_payload.json
@@ -1,0 +1,119 @@
+{
+  "resources": [
+    {
+      "type": "docman_metadata",
+      "uri": "projects/118/docman_metadata"
+    },
+    {
+      "type": "docman_service",
+      "uri": "projects/118/docman_service"
+    },
+    {
+      "type": "trackers",
+      "uri": "projects/118/trackers"
+    },
+    {
+      "type": "backlog",
+      "uri": "projects/118/backlog"
+    },
+    {
+      "type": "milestones",
+      "uri": "projects/118/milestones"
+    },
+    {
+      "type": "plannings",
+      "uri": "projects/118/plannings"
+    },
+    {
+      "type": "git",
+      "uri": "projects/118/git"
+    },
+    {
+      "type": "svn",
+      "uri": "projects/118/svn"
+    },
+    {
+      "type": "testmanagement_campaigns",
+      "uri": "projects/118/testmanagement_campaigns"
+    },
+    {
+      "type": "testmanagement_definitions",
+      "uri": "projects/118/testmanagement_definitions"
+    },
+    {
+      "type": "testmanagement_nodes",
+      "uri": "projects/118/testmanagement_nodes"
+    },
+    {
+      "type": "frs_packages",
+      "uri": "projects/118/frs_packages"
+    },
+    {
+      "type": "frs_service",
+      "uri": "projects/118/frs_service"
+    },
+    {
+      "type": "project_services",
+      "uri": "projects/118/project_services"
+    },
+    {
+      "type": "user_groups",
+      "uri": "projects/118/user_groups"
+    },
+    {
+      "type": "phpwiki",
+      "uri": "projects/118/phpwiki"
+    },
+    {
+      "type": "heartbeats",
+      "uri": "projects/118/heartbeats"
+    },
+    {
+      "type": "labels",
+      "uri": "projects/118/labels"
+    }
+  ],
+  "additional_informations": {
+    "agiledashboard": {
+      "root_planning": {
+        "id": 29,
+        "uri": "route-not-yet-implemented",
+        "label": "Release Planning",
+        "project": {
+          "id": 118,
+          "uri": "projects/118",
+          "label": null
+        },
+        "milestone_tracker": {
+          "id": 155,
+          "uri": "trackers/155",
+          "label": "Releases",
+          "project": {
+            "id": 118,
+            "uri": "projects/118",
+            "label": "Use Me"
+          }
+        },
+        "backlog_trackers": [
+          {
+            "id": 153,
+            "uri": "trackers/153"
+          },
+          {
+            "id": 160,
+            "uri": "trackers/160"
+          }
+        ],
+        "milestones_uri": "plannings/29/milestones"
+      }
+    }
+  },
+  "is_member_of": true,
+  "id": 118,
+  "uri": "projects/118",
+  "label": "Use Me",
+  "shortname": "use-me",
+  "status": "active",
+  "access": "public",
+  "is_template": false
+}


### PR DESCRIPTION
Part of [request #22618](https://tuleap.net/plugins/tracker/?aid=22618) Stop using the deprecated client in Jenkins plugin


