### PR TITLE
Add head_reference to the PullRequest interface

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/PullRequest.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/PullRequest.java
@@ -17,5 +17,7 @@ public interface PullRequest {
 
     String getStatus();
 
+    String getHeadReference();
+
     GitHead getHead();
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/PullRequestEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/PullRequestEntity.java
@@ -16,6 +16,7 @@ public class PullRequestEntity implements PullRequest {
     private final String sourceReference;
     private final String destinationReference;
     private final String status;
+    private final String headReference;
     private final GitHeadEntity head;
 
     public PullRequestEntity(
@@ -27,6 +28,7 @@ public class PullRequestEntity implements PullRequest {
         @JsonProperty("reference_src") String sourceReference,
         @JsonProperty("reference_dest") String destinationReference,
         @JsonProperty("status") String status,
+        @JsonProperty("head_reference") String headReference,
         @JsonProperty("head") GitHeadEntity head
     ) {
         this.id = id;
@@ -37,6 +39,7 @@ public class PullRequestEntity implements PullRequest {
         this.sourceReference = sourceReference;
         this.destinationReference = destinationReference;
         this.status = status;
+        this.headReference = headReference;
         this.head = head;
     }
 
@@ -78,6 +81,11 @@ public class PullRequestEntity implements PullRequest {
     @Override
     public String getStatus() {
         return this.status;
+    }
+
+    @Override
+    public String getHeadReference() {
+        return this.headReference;
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -619,7 +619,7 @@ public class TuleapApiClientTest {
 
         TuleapAccessToken accessToken = this.getTuleapAccessTokenStubClass();
 
-        PullRequest expectedPullRequest = new PullRequestEntity("4", new GitRepositoryReferenceEntity("u/darwinw/repo001", 18), new GitRepositoryReferenceEntity("repo001", 4), "from-fork", "pr5","95fd78ba6238cfeac8d6a10874353130da04b1d7","10c9cddf27ee6cd2ab15b652922c9da7d8cf60fd","review", new GitHeadEntity("95fd78ba6238cfeac8d6a10874353130da04b1d7"));
+        PullRequest expectedPullRequest = new PullRequestEntity("4", new GitRepositoryReferenceEntity("u/darwinw/repo001", 18), new GitRepositoryReferenceEntity("repo001", 4), "from-fork", "pr5","95fd78ba6238cfeac8d6a10874353130da04b1d7","10c9cddf27ee6cd2ab15b652922c9da7d8cf60fd","review", "refs/tlpr/4/head", new GitHeadEntity("95fd78ba6238cfeac8d6a10874353130da04b1d7"));
 
         PullRequest currentPullRequest = this.tuleapApiClient.getPullRequest("4", accessToken);
 
@@ -632,6 +632,7 @@ public class TuleapApiClientTest {
         assertEquals(expectedPullRequest.getSourceRepository().getId(), currentPullRequest.getSourceRepository().getId());
         assertEquals(expectedPullRequest.getSourceRepository().getName(), currentPullRequest.getSourceRepository().getName());
         assertEquals(expectedPullRequest.getDestinationRepository().getName(), currentPullRequest.getDestinationRepository().getName());
+        assertEquals(expectedPullRequest.getHeadReference(), currentPullRequest.getHeadReference());
         assertEquals(expectedPullRequest.getHead().getId(), currentPullRequest.getHead().getId());
     }
 


### PR DESCRIPTION
This change is a needed patch to fix [Tuleap #23048](https://tuleap.net/plugins/tracker/?aid=23048)

We are now storing the `head_reference` field into the PullRequest
interface.
