### PR TITLE
Support the pull request `title` key in GitPullRequest

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitPullRequest.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitPullRequest.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.tuleap_api.client;
 public interface GitPullRequest {
     String getId();
 
+    String getTitle();
+
     GitRepositoryReference getSourceRepository();
 
     GitRepositoryReference getDestinationRepository();

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitPullRequestEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitPullRequestEntity.java
@@ -8,6 +8,7 @@ import io.jenkins.plugins.tuleap_api.client.GitRepositoryReference;
 public class GitPullRequestEntity implements GitPullRequest {
 
     private final String id;
+    private final String title;
     private final GitRepositoryReference sourceRepository;
     private final GitRepositoryReference destinationRepository;
     private final String sourceBranch;
@@ -16,12 +17,14 @@ public class GitPullRequestEntity implements GitPullRequest {
 
     public GitPullRequestEntity(
         @JsonProperty("id") String id,
+        @JsonProperty("title") String title,
         @JsonProperty("repository") GitRepositoryReferenceEntity sourceRepository,
         @JsonProperty("repository_dest") GitRepositoryReferenceEntity destinationRepository,
         @JsonProperty("branch_src") String sourceBranch,
         @JsonProperty("branch_dest") String destinationBranch,
         @JsonProperty("head") GitHeadEntity head) {
         this.id = id;
+        this.title = title;
         this.sourceRepository = sourceRepository;
         this.destinationRepository = destinationRepository;
         this.sourceBranch = sourceBranch;
@@ -32,6 +35,11 @@ public class GitPullRequestEntity implements GitPullRequest {
     @Override
     public String getId() {
         return this.id;
+    }
+
+    @Override
+    public String getTitle() {
+        return this.title;
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -565,8 +565,8 @@ public class TuleapApiClientTest {
 
         TuleapAccessToken accessToken = this.getTuleapAccessTokenStubClass();
 
-        GitPullRequest pr1 = new GitPullRequestEntity("1", new GitRepositoryReferenceEntity("repo001", 4), new GitRepositoryReferenceEntity("repo001", 4), "pr1", "master", new GitHeadEntity("9e419faf4a8cc2614ae536e995fa0528dad44b01"));
-        GitPullRequest pr2 = new GitPullRequestEntity("2", new GitRepositoryReferenceEntity("u/darwinw/repo001", 18), new GitRepositoryReferenceEntity("repo001", 4), "from-fork", "pr5", new GitHeadEntity("95fd78ba6238cfeac8d6a10874353130da04b1d7"));
+        GitPullRequest pr1 = new GitPullRequestEntity("1","add file in pr1", new GitRepositoryReferenceEntity("repo001", 4), new GitRepositoryReferenceEntity("repo001", 4), "pr1", "master", new GitHeadEntity("9e419faf4a8cc2614ae536e995fa0528dad44b01"));
+        GitPullRequest pr2 = new GitPullRequestEntity("2", "new message from fork", new GitRepositoryReferenceEntity("u/darwinw/repo001", 18), new GitRepositoryReferenceEntity("repo001", 4), "from-fork", "pr5", new GitHeadEntity("95fd78ba6238cfeac8d6a10874353130da04b1d7"));
 
         List<GitPullRequest> expectedPullRequests = ImmutableList.of(pr1,pr2);
         List<GitPullRequest> currentPullRequests = this.tuleapApiClient.getPullRequests("4", accessToken);
@@ -580,6 +580,7 @@ public class TuleapApiClientTest {
                 .orElseThrow(RuntimeException::new);
 
             assertEquals(expectedPullRequest.getId(), pullRequest.getId());
+            assertEquals(expectedPullRequest.getTitle(), pullRequest.getTitle());
             assertEquals(expectedPullRequest.getSourceBranch(), pullRequest.getSourceBranch());
             assertEquals(expectedPullRequest.getDestinationBranch(), pullRequest.getDestinationBranch());
             assertEquals(expectedPullRequest.getSourceRepository().getId(), pullRequest.getSourceRepository().getId());

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_pull_requests_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_pull_requests_payload.json
@@ -39,7 +39,7 @@
     },
     {
       "id": 2,
-      "title": "new lessage from fork",
+      "title": "new message from fork",
       "uri": "pull_requests/4",
       "repository": {
         "name": "u/darwinw/repo001",


### PR DESCRIPTION
Part of [request #23441](https://tuleap.net/plugins/tracker/?aid=23441) Display the title of the PR instead of TLP-PR-<id>

This commit introduce the request
