### PR TITLE
Use the Jackson API from Jenkins

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.1.0
+      - uses: actions/setup-java@v3.1.1
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.1.1
+      - uses: actions/setup-java@v3.4.0
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.1.1
+      - uses: actions/setup-java@v3.4.0
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.1.0
+      - uses: actions/setup-java@v3.1.1
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>2.4.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Tuleap API Plugin</name>
@@ -45,8 +45,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1472.vb_65d893c9a_b_6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
             <version>4.9.3</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.2</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>2.13.3-285.vc03c0256d517</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.5</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                 </plugin>

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitApi.java
@@ -16,6 +16,7 @@ public interface GitApi {
     String TREE = "/tree";
     String FILES = "/files";
     String PULL_REQUEST = "/pull_requests";
+    String BRANCHES = "/branches";
 
     void sendBuildStatus(String repositoryId, String commitReference, TuleapBuildStatus status, StringCredentials credentials);
 
@@ -28,4 +29,6 @@ public interface GitApi {
     GitFileContent getFileContent(String repositoryId, String path, String commitReference, TuleapAccessToken token) throws FileContentNotFoundException;
 
     List<GitPullRequest> getPullRequests(String repositoryId, TuleapAccessToken token);
+
+    List<GitBranch> getBranches(String repositoryId, TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitBranch.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitBranch.java
@@ -1,0 +1,7 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+public interface GitBranch {
+    String getName();
+
+    GitCommit getCommit();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitRepositories.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitRepositories.java
@@ -1,0 +1,7 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+import java.util.List;
+
+public interface GitRepositories {
+    List<? extends GitRepository> getGitRepositories();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/GitRepository.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/GitRepository.java
@@ -1,0 +1,9 @@
+package io.jenkins.plugins.tuleap_api.client;
+
+public interface GitRepository {
+    String getName();
+
+    Integer getId();
+
+    String getPath();
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
@@ -18,4 +18,5 @@ public interface ProjectApi {
     Project getProjectById(String projectId, TuleapAccessToken token) ;
     List<UserGroup> getProjectUserGroups(Integer projectId, AccessToken token);
     List<GitRepository> getGitRepositories(Integer projectId, TuleapAccessToken token);
+    List<Project> getUserProjects(TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/ProjectApi.java
@@ -10,8 +10,12 @@ public interface ProjectApi {
 
     String PROJECT_API = "/projects";
     String PROJECT_GROUPS = "/user_groups";
+    String PROJECT_GIT = "/git";
+
+    String PROJECT_MEMBER_OF_QUERY = "{\"is_member_of\":true}";
 
     Project getProjectByShortname(String shortname, AccessToken token) throws ProjectNotFoundException;
     Project getProjectById(String projectId, TuleapAccessToken token) ;
     List<UserGroup> getProjectUserGroups(Integer projectId, AccessToken token);
+    List<GitRepository> getGitRepositories(Integer projectId, TuleapAccessToken token);
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClient.java
@@ -285,11 +285,55 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
 
             return new ArrayList<>(this.objectMapper.readValue(
                 Objects.requireNonNull(response.body()).string(),
-                new TypeReference<List<MinimalUserGroupEntity>>() {}
+                new TypeReference<List<MinimalUserGroupEntity>>() {
+                }
             ));
         } catch (IOException | InvalidTuleapResponseException e) {
             throw new RuntimeException("Error while contacting Tuleap server", e);
         }
+    }
+
+    @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
+    public List<GitRepository> getGitRepositories(Integer projectId, TuleapAccessToken token) {
+        int offset = 0;
+        int totalSize;
+
+        List<GitRepository> allRepositories = new ArrayList<>();
+
+        do {
+            HttpUrl urlGetProjectRepositories = Objects.requireNonNull(HttpUrl.parse(this.tuleapConfiguration.getApiBaseUrl() + this.PROJECT_API + "/" + projectId + this.PROJECT_GIT))
+                .newBuilder()
+                .addEncodedQueryParameter("limit", Integer.toString(PAGE_SIZE))
+                .addEncodedQueryParameter("offset", Integer.toString(offset))
+                .build();
+
+            Request request = new Request.Builder()
+                .url(urlGetProjectRepositories)
+                .addHeader(this.AUTHORIZATION_HEADER, token.getToken().getPlainText())
+                .get()
+                .build();
+
+            try (Response response = this.client.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    throw new InvalidTuleapResponseException(response);
+                }
+
+                GitRepositories repositories = this.objectMapper.readValue(
+                    Objects.requireNonNull(response.body()).string(),
+                    GitRepositoriesEntity.class
+                );
+
+                allRepositories.addAll(repositories.getGitRepositories());
+
+                totalSize = Integer.parseInt(Objects.requireNonNull(response.header(COLLECTION_LENGTH_HEADER)));
+                offset = offset + PAGE_SIZE;
+
+            } catch (InvalidTuleapResponseException | IOException e) {
+                throw new RuntimeException("Error while contacting Tuleap server", e);
+            }
+        } while (offset < totalSize);
+        return allRepositories;
     }
 
     @Override
@@ -300,7 +344,7 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
             request = new Request.Builder()
                 .url(this.tuleapConfiguration.getApiBaseUrl() + this.TEST_CAMPAIGN_API + "/" + campaignId)
                 .addHeader(this.AUTHORIZATION_HEADER, secret.getPlainText())
-                .patch(RequestBody.create(this.objectMapper.writer(SerializationFeature.WRAP_ROOT_VALUE).writeValueAsString(new SendTTMResultsEntity(buildUrl,results)), JSON))
+                .patch(RequestBody.create(this.objectMapper.writer(SerializationFeature.WRAP_ROOT_VALUE).writeValueAsString(new SendTTMResultsEntity(buildUrl, results)), JSON))
                 .build();
         } catch (JsonProcessingException exception) {
             throw new RuntimeException("Error while trying to create request for TTM results", exception);
@@ -492,6 +536,51 @@ public class TuleapApiClient implements TuleapAuthorization, AccessKeyApi, UserA
                 throw new RuntimeException("Error while contacting Tuleap server", e);
             }
         }
+    }
+
+    @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE") // see https://github.com/spotbugs/spotbugs/issues/651
+    public List<GitBranch> getBranches(String repositoryId, TuleapAccessToken token) {
+        int offset = 0;
+        int totalSize;
+
+        List<GitBranch> branches = new ArrayList<>();
+
+        do {
+            HttpUrl urlGetPR = Objects.requireNonNull(HttpUrl.parse(this.tuleapConfiguration.getApiBaseUrl() + this.GIT_API + "/" + repositoryId + this.BRANCHES))
+                .newBuilder()
+                .addEncodedQueryParameter("limit", Integer.toString(PAGE_SIZE))
+                .addEncodedQueryParameter("offset", Integer.toString(offset))
+                .build();
+
+            Request request = new Request.Builder()
+                .url(urlGetPR)
+                .addHeader(this.AUTHORIZATION_HEADER, token.getToken().getPlainText())
+                .get()
+                .build();
+
+            try (Response response = this.client.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    throw new InvalidTuleapResponseException(response);
+                }
+
+                List<GitBranch> currentPageBranches = new ArrayList<>(this.objectMapper.readValue(
+                    Objects.requireNonNull(response.body()).string(),
+                    new TypeReference<List<GitBranchEntity>>() {
+                    }
+                ));
+
+                branches.addAll(currentPageBranches);
+
+                totalSize = Integer.parseInt(Objects.requireNonNull(response.header(COLLECTION_LENGTH_HEADER)));
+                offset = offset + PAGE_SIZE;
+
+            } catch (InvalidTuleapResponseException | IOException e) {
+                throw new RuntimeException("Error while contacting Tuleap server", e);
+            }
+        } while (offset < totalSize);
+
+        return branches;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitBranchEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitBranchEntity.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitBranch;
+import io.jenkins.plugins.tuleap_api.client.GitCommit;
+
+final public class GitBranchEntity implements GitBranch {
+
+    private final String name;
+    private final GitCommitEntity commit;
+
+    public GitBranchEntity(@JsonProperty("name") String name, @JsonProperty("commit") GitCommitEntity commit){
+        this.name = name;
+        this.commit = commit;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public GitCommit getCommit() {
+        return this.commit;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitRepositoriesEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitRepositoriesEntity.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitRepositories;
+import io.jenkins.plugins.tuleap_api.client.GitRepository;
+
+import java.util.List;
+
+final public class GitRepositoriesEntity implements GitRepositories {
+
+    private List<GitRepositoryEntity> repositories;
+
+    public GitRepositoriesEntity(@JsonProperty("repositories") List<GitRepositoryEntity> repositories){
+        this.repositories = repositories;
+    }
+
+    @Override
+    public List<? extends GitRepository> getGitRepositories() {
+        return this.repositories;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitRepositoryEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitRepositoryEntity.java
@@ -1,0 +1,35 @@
+package io.jenkins.plugins.tuleap_api.client.internals.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jenkins.plugins.tuleap_api.client.GitRepository;
+
+final public class GitRepositoryEntity implements GitRepository {
+
+    private final String name;
+    private final Integer id;
+    private final String path;
+
+    public GitRepositoryEntity(@JsonProperty("name") String name,
+                               @JsonProperty("id") Integer id,
+                               @JsonProperty("path") String path)
+    {
+        this.name = name;
+        this.id = id;
+        this.path = path;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getPath() {
+        return this.path;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Queue;
@@ -26,7 +27,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
-import javax.annotation.CheckForNull;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -25,7 +26,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
-import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.*;

--- a/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_api/client/internals/TuleapApiClientTest.java
@@ -29,7 +29,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -799,6 +798,45 @@ public class TuleapApiClientTest {
         assertEquals(2, repositories.get(1).getId().intValue());
         assertEquals("repo-Pouet", repositories.get(1).getName());
         assertEquals("alm/repo-Pouet.git", repositories.get(1).getPath());
+
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void itThrowsAnExceptionWhenUserProjectCannotBeRetrieved() throws IOException {
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.isSuccessful()).thenReturn(false);
+
+        tuleapApiClient.getUserProjects(this.getTuleapAccessTokenStubClass());
+    }
+
+    @Test
+    public void itReturnsUserProjects() throws IOException {
+        TuleapAccessToken tuleapAccessToken = this.getTuleapAccessTokenStubClass();
+        Call call = mock(Call.class);
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+        String payload = IOUtils.toString(TuleapApiClientTest.class.getResourceAsStream("project_payload.json"), UTF_8);
+
+        when(client.newCall(any())).thenReturn(call);
+        when(call.execute()).thenReturn(response);
+        when(response.code()).thenReturn(200);
+        when(response.isSuccessful()).thenReturn(true);
+        when(response.body()).thenReturn(responseBody);
+        when(response.header("x-pagination-size")).thenReturn("1");
+        when(responseBody.string())
+            .thenReturn(payload);
+
+        List<Project> projects = tuleapApiClient.getUserProjects( tuleapAccessToken);
+
+        assertEquals("use-me", projects.get(0).getShortname());
+        Integer expectedId = 118;
+        assertEquals(expectedId, projects.get(0).getId());
+        assertEquals("Use Me", projects.get(0).getLabel());
+        assertEquals("projects/118", projects.get(0).getUri());
 
     }
 }

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/project_git_payload.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/project_git_payload.json
@@ -1,0 +1,36 @@
+{
+  "repositories": [
+    {
+      "id": 1,
+      "uri": "git/1",
+      "name": "Some-repo",
+      "label": "Some-repo",
+      "path": "alm/Some-repo.git",
+      "path_without_project": "",
+      "description": "-- Default description --",
+      "last_update_date": "2022-04-01T17:18:51+02:00",
+      "permissions": null,
+      "server": null,
+      "html_url": "/plugins/git/alm/Some-repo",
+      "default_branch": "master",
+      "additional_information": {
+        "opened_pull_requests": 1
+      }
+    },
+    {
+      "id": 2,
+      "uri": "git/2",
+      "name": "repo-Pouet",
+      "label": "repo-Pouet",
+      "path": "alm/repo-Pouet.git",
+      "path_without_project": "",
+      "description": "-- Default description --",
+      "last_update_date": "2022-05-06T12:22:38+02:00",
+      "permissions": null,
+      "server": null,
+      "html_url": "/plugins/git/alm/repo-Pouet",
+      "default_branch": "main",
+      "additional_information": []
+    }
+  ]
+}

--- a/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_branches_payload1.json
+++ b/src/test/resources/io/jenkins/plugins/tuleap_api/client/internals/tuleap_git_branches_payload1.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "pr1",
+    "commit": {
+      "id": "04e78f9352cdd9a2adf71a3f2c4bcb9f03359a59",
+      "author_name": "Coco L'Asticot",
+      "authored_date": "2022-03-31T16:35:15+02:00",
+      "committed_date": "2022-03-31T16:35:15+02:00",
+      "title": "Tonight! on some emission",
+      "message": "I wear a hat, my colleague wears a hat, and the third wears a yellow hat",
+      "author_email": "asticotc@example.com",
+      "author": "Coco L'Ascticot",
+      "html_url": "/plugins/git/alm/repo001?a=commit&h=38dfa09a67d7872d821b6a46eff340bc8ae0af0f",
+      "commit_status": null,
+      "verification": {
+        "signature": null
+      }
+    }
+  },
+  {
+    "name": "master",
+    "commit": {
+      "id": "4ca3f8df4dd86b904da7847dc97cdfac92b55110",
+      "author_name": "Coco L'Asticot",
+      "authored_date": "2022-03-31T16:34:36+02:00",
+      "committed_date": "2022-03-31T16:34:36+02:00",
+      "title": "On Bottom Gear!",
+      "message": "I flex with my hood, my colleague steals some weed from Snoop Dogg, and the third becomes a Soundcloud rapper",
+      "author_email": "asticotc@example.com",
+      "author": "Coco L'Ascticot",
+      "html_url": "/plugins/git/alm/repo001?a=commit&h=38dfa09a67d7872d821b6a46eff340bc8ae0af0f",
+      "commit_status": null,
+      "verification": {
+        "signature": null
+      }
+    }
+  }
+]


### PR DESCRIPTION
[request #25334](https://tuleap.net/plugins/tracker/?aid=25334) Use the Jackson 2 API plugin instead of maven dependency

To make the plugin works, we have to also bump the minimum version of Jenkins
to 2.249.1

No functional change expected
