### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Build
         run: mvn -Dmaven.test.skip=true -Dspotbugs.skip=true --batch-mode --show-version clean install 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - name: Build
         run: mvn -Pjacoco clean verify --batch-mode --show-version


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage
