### PR TITLE
Update minimum Jenkins version to 2.289.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>2.4.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Tuleap API Plugin</name>
@@ -45,8 +45,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>984.vb5eaac999a7e</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1472.vb_65d893c9a_b_6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapNotifyCommitStatusStep.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Queue;
@@ -26,7 +27,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
-import javax.annotation.CheckForNull;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/steps/TuleapSendTTMResultsStep.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -25,7 +26,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
-import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.*;


### PR DESCRIPTION
Part of [request #25334](https://tuleap.net/plugins/tracker/?aid=25334) Use the Jackson 2 API plugin instead of maven dependency

Update to Jenkins 2.289.3 as our current version is rather outdated and
makes swapping to more reasonable dependencies (jackson2-api-plugin)
quite tedious.
