### PR TITLE
Use Java 17 to build the plugin.

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   build:
     name: Build and archive
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - name: Build
         run: mvn -Dmaven.test.skip=true -Dspotbugs.skip=true --batch-mode --show-version clean install 
       - name: Archive

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
   tests-with-coverage:
     strategy:
       matrix:
-        os: ["windows-2019", "ubuntu-20.04"]
+        os: ["windows-2019", "ubuntu-22.04"]
     name: Tests (${{ matrix.os }}) with coverage
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '17'
       - name: Build
         run: mvn -Pjacoco clean verify --batch-mode --show-version
       - name: Upload coverage to Codecov

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.39</version>
+        <version>4.54</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,7 +12,7 @@
     <version>2.5.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Tuleap API Plugin</name>
@@ -45,8 +45,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
-                <version>1500.ve4d05cd32975</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1742.vb_70478c1b_25f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Part of [request #30740](https://tuleap.net/plugins/tracker/?aid=30740) Build Tuleap API with Java 17

No functional change expected

