### PR TITLE
Closes request #33993: Pull request title should use the "raw" title

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitPullRequestEntity.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_api/client/internals/entities/GitPullRequestEntity.java
@@ -17,7 +17,7 @@ public class GitPullRequestEntity implements GitPullRequest {
 
     public GitPullRequestEntity(
         @JsonProperty("id") String id,
-        @JsonProperty("title") String title,
+        @JsonProperty("raw_title") String title,
         @JsonProperty("repository") GitRepositoryReferenceEntity sourceRepository,
         @JsonProperty("repository_dest") GitRepositoryReferenceEntity destinationRepository,
         @JsonProperty("branch_src") String sourceBranch,


### PR DESCRIPTION
For most usages within (all at the moment?) the usage of the "raw" title is preferable as we cannot render HTML. This contribution uses the "raw" title for the existing `::getTitle()` method, if later on we also need the HTML version another can be added.

https://tuleap.net/plugins/tracker/?aid=33993