### PR TITLE
Test and build with Java 17

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-java@v3.12.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Build
         run: mvn -Dmaven.test.skip=true -Dspotbugs.skip=true --batch-mode --show-version clean install 
       - name: Archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           path: target/tuleap-api.hpi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,19 +12,19 @@ jobs:
   tests-with-coverage:
     strategy:
       matrix:
-        os: ["windows-2019", "ubuntu-22.04"]
+        os: ["windows-2022", "ubuntu-22.04"]
     name: Tests (${{ matrix.os }}) with coverage
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-java@v3.12.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Build
         run: mvn -Pjacoco clean verify --batch-mode --show-version
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           file: ./target/site/jacoco/jacoco.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
Java 11 support will be considered end of life by Jenkins in September.
